### PR TITLE
Tag error messages with field in ecto validator

### DIFF
--- a/lib/exiban/ecto_validator.ex
+++ b/lib/exiban/ecto_validator.ex
@@ -35,6 +35,7 @@ defmodule ExIban.EctoValidator do
         new_errors = new_errors
                       |> Enum.map(&Atom.to_string/1)
                       |> Enum.map(&(String.replace(&1, "_", " ")))
+                      |> Enum.map(&({field, &1}))
         %{changeset | errors: new_errors ++ errors, valid?: false}
       :ok -> changeset
     end


### PR DESCRIPTION
Hi! Thanks for a great library. I am using it inside Phoenix application.

This pull request tags error messages inside changesets with field name, so they can be used in phoenix forms.

To use `<%= error_tag f, :iban %>` in views error messages have to be tuples `{field, error_msg}`. This is a single line change and does not require modifying tests. It would be really helpful for me if this change made its way to hex :)
