### PR TITLE
Resolve the compilation warnings

### DIFF
--- a/lib/exiban.ex
+++ b/lib/exiban.ex
@@ -94,7 +94,7 @@ defmodule ExIban do
     {_, _, _, _, formatted} = parse(iban)
     formatted
     |> String.replace(~r/(.{4})/, "\\1 ")
-    |> String.strip
+    |> String.trim
   end
 
   @doc """
@@ -110,7 +110,7 @@ defmodule ExIban do
   def format_compact(iban) do
     {_, _, _, _, formatted} = parse(iban)
     formatted
-    |> String.strip
+    |> String.trim
   end
 
   defp prepare_output({[], _}), do: :ok

--- a/lib/exiban/parser.ex
+++ b/lib/exiban/parser.ex
@@ -29,7 +29,7 @@ defmodule ExIban.Parser do
   defp normalize(iban) do
     iban
     |> String.replace(~r/\s+/, "")
-    |> String.strip
+    |> String.trim
     |> String.upcase
   end
 end

--- a/lib/exiban/validators.ex
+++ b/lib/exiban/validators.ex
@@ -3,7 +3,6 @@ defmodule ExIban.Validators do
   Set of validation rules to perform on checking IBAN account number.
   """
 
-  import ExIban.Rules
   import ExIban.Parser
 
   @doc """
@@ -53,7 +52,7 @@ defmodule ExIban.Validators do
 
   defp check_country_code({errors, {country_code, _, _, _, _} = parsed_iban}) do
     cond do
-      rules |> Map.get(country_code) |> is_nil ->
+      ExIban.Rules.rules |> Map.get(country_code) |> is_nil ->
         {errors ++ [:unknown_country_code], parsed_iban}
       true -> {errors, parsed_iban}
     end
@@ -62,7 +61,7 @@ defmodule ExIban.Validators do
   defp check_length({errors,
     {country_code, _, _, iban_length, _} = parsed_iban}) do
     cond do
-      rules |> Map.get(country_code, %{}) |> Map.get("length") != iban_length ->
+      ExIban.Rules.rules |> Map.get(country_code, %{}) |> Map.get("length") != iban_length ->
         {errors ++ [:bad_length], parsed_iban}
       true -> {errors, parsed_iban}
     end
@@ -70,7 +69,7 @@ defmodule ExIban.Validators do
 
   defp check_format({errors,
     {country_code, _, bban, _, _} = parsed_iban}) do
-    {:ok, reg} = rules
+    {:ok, reg} = ExIban.Rules.rules
                   |> Map.get(country_code, %{})
                   |> Map.get("bban_pattern", "")
                   |> Regex.compile

--- a/lib/exiban/validators.ex
+++ b/lib/exiban/validators.ex
@@ -82,7 +82,7 @@ defmodule ExIban.Validators do
 
   defp check_digits({errors,
     {country_code, check_digits, bban, _, _} = parsed_iban}) do
-    chars = String.to_char_list(bban <> country_code <> check_digits)
+    chars = String.to_charlist(bban <> country_code <> check_digits)
     numbers = for byte <- chars, into: [] do
       case byte do
         byte when byte in 48..57 -> List.to_string([byte])

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,6 @@
-%{"dogma": {:hex, :dogma, "0.1.0"},
-  "earmark": {:hex, :earmark, "0.2.1"},
-  "ex_doc": {:hex, :ex_doc, "0.11.4"},
-  "poison": {:hex, :poison, "1.5.2"}}
+%{
+  "dogma": {:hex, :dogma, "0.1.0"},
+  "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], [], "hexpm", "c86afb8d22a5aa8315afd4257c7512011c0c9a48b0fea43af7612836b958098b"},
+  "ex_doc": {:hex, :ex_doc, "0.11.4", "a064bdb720594c3745b94709b17ffb834fd858b4e0c1f48f37c0d92700759e02", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, repo: "hexpm", optional: true]}], "hexpm", "639e97b24c1c6c172f557163b830673646983417de9ac0da2c25c7063deed293"},
+  "poison": {:hex, :poison, "1.5.2"},
+}


### PR DESCRIPTION
Warning: variable "rules" does not exist
Deprecations of String.strip/1 and String.to_char_list/1
