### PR TITLE
Improve IBAN validation

### DIFF
--- a/lib/exiban/parser.ex
+++ b/lib/exiban/parser.ex
@@ -14,7 +14,7 @@ defmodule ExIban.Parser do
   """
 
   @spec parse(binary) :: {bitstring, bitstring, bitstring, integer, bitstring}
-  def parse(iban) do
+  def parse(iban) when byte_size(iban) > 3 do
     iban = iban |> normalize
 
     {
@@ -25,6 +25,8 @@ defmodule ExIban.Parser do
       iban
     }
   end
+
+  def parse(_iban), do: {:error, :invalid_iban}
 
   defp normalize(iban) do
     iban


### PR DESCRIPTION
 - Return invalid_iban when iban size is less than 4 bytes

The following error was raised:

```bash
  1) test parse returns error when receive single char as parameter (ExIban.ParserTest)
     test/parser_test.exs:5
     ** (FunctionClauseError) no function clause matching in String.slice/3

     The following arguments were given to String.slice/3:
     
         # 1
         "-"
     
         # 2
         4
     
         # 3
         -3
     
     Attempted function clauses (showing 3 out of 3):
     
         def slice(_, _, 0)
         def slice(string, start, length) when is_binary(string) and is_integer(start) and is_integer(length) and start >= 0 and length >= 0
         def slice(string, start, length) when is_binary(string) and is_integer(start) and is_integer(length) and start < 0 and length >= 0
     
     code: {:error, :invalid_iban} = ExIban.Parser.parse("-")
     stacktrace:
       (elixir 1.14.2) lib/string.ex:2111: String.slice/3
       (exiban 0.0.6) lib/exiban/parser.ex:23: ExIban.Parser.parse/1
       test/parser_test.exs:6: (test)
```